### PR TITLE
support timeTravel from imported states

### DIFF
--- a/apps/sample-app/src/app/app.module.ts
+++ b/apps/sample-app/src/app/app.module.ts
@@ -39,6 +39,7 @@ import { LoadingWithDefaultValuesComponent } from './loading-store/default-value
       name: 'ngrx-lite-demo',
       maxAge: 25,
       logOnly: false,
+      monitor: (state, action) => action
     }),
     AppRoutingModule,
     MatButtonModule,

--- a/libs/store/src/router-store/router-store.module.ts
+++ b/libs/store/src/router-store/router-store.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import {RouterStore} from "./router-service";
+import { RouterStore } from './router-service';
 
 @NgModule({
   imports: [BrowserModule],

--- a/libs/store/src/services/action-creator.ts
+++ b/libs/store/src/services/action-creator.ts
@@ -25,4 +25,4 @@ export const getCustomAction = <P extends object>({
   storeName: string;
   actionName?: string;
 }) =>
-  createAction<string, { payload: P }>(`[${storeName}] ${actionName}`, props());
+  createAction<string, { payload: P }>(`[COMPONENT_STORE][${storeName}] ${actionName}`, props());

--- a/libs/store/src/services/store-factory.service.spec.ts
+++ b/libs/store/src/services/store-factory.service.spec.ts
@@ -24,6 +24,8 @@ describe('StoreFactory', () => {
 
   const store = jasmine.createSpyObj<Store>('Store', {
     createStoreByStoreType: undefined,
+    addReducersForImportedState: undefined,
+    checkForTimeTravel: undefined
   });
 
   let storeFactory: StoreFactory;

--- a/libs/store/src/services/store-factory.service.ts
+++ b/libs/store/src/services/store-factory.service.ts
@@ -13,7 +13,11 @@ type StoragePluginTypes = 'sessionStoragePlugin' | 'localStoragePlugin';
 
 @Injectable({ providedIn: 'root' })
 export class StoreFactory {
-  constructor(private store: Store) {}
+  constructor(private store: Store) {
+
+    store.checkForTimeTravel();
+    store.addReducersForImportedState();
+  }
 
   public createComponentStore<STATE extends object>({
     storeName,


### PR DESCRIPTION
It's necessary to configure `monitor` in the devTools Options, to support import states

```ts
StoreDevtoolsModule.instrument({
   //
    monitor: (state, action) => action
}),
```

close #34