### PR TITLE
Remove reducer after store destroy (only if no Devtools configured )

### DIFF
--- a/libs/store/src/services/dev-tool-helper.service.ts
+++ b/libs/store/src/services/dev-tool-helper.service.ts
@@ -1,0 +1,14 @@
+import {Injectable} from "@angular/core";
+
+@Injectable({ providedIn: 'root' })
+export class DevToolHelper {
+  private _isTimeTravelActive = false;
+
+  setTimeTravelActive(isTimeTravelActive: boolean) {
+    this._isTimeTravelActive = isTimeTravelActive;
+  }
+
+  isTimeTravelActive(): boolean {
+    return this._isTimeTravelActive;
+  }
+}

--- a/libs/store/src/services/store-factory.service.spec.ts
+++ b/libs/store/src/services/store-factory.service.spec.ts
@@ -24,7 +24,7 @@ describe('StoreFactory', () => {
 
   const store = jasmine.createSpyObj<Store>('Store', {
     createStoreByStoreType: undefined,
-    addReducersForImportedState: undefined,
+    addReducersForImportState: undefined,
     checkForTimeTravel: undefined
   });
 

--- a/libs/store/src/services/store-factory.service.spec.ts
+++ b/libs/store/src/services/store-factory.service.spec.ts
@@ -4,10 +4,11 @@ import { ComponentLoadingStore } from './stores/component-loading-store.service'
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { cold } from 'jasmine-marbles';
 import { StoreFactory } from './store-factory.service';
-import { ComponentStore, DevToolHelper } from './stores/component-store.service';
+import { ComponentStore } from './stores/component-store.service';
 import { Store } from './store.service';
 import { Injector } from '@angular/core';
 import { StateToken, StoreNameToken } from '../injection-tokens/state.token';
+import {DevToolHelper} from "./dev-tool-helper.service";
 
 interface MyState {
   myState: string;
@@ -18,8 +19,8 @@ const defaultMyState: MyState = { myState: '' };
 
 describe('StoreFactory', () => {
   const devToolHelper = jasmine.createSpyObj<DevToolHelper>('storeDevtools', {
-    canChangeState: true,
-    setCanChangeState: undefined,
+    isTimeTravelActive: false,
+    setTimeTravelActive: undefined,
   });
 
   const store = jasmine.createSpyObj<Store>('Store', {

--- a/libs/store/src/services/store-factory.service.ts
+++ b/libs/store/src/services/store-factory.service.ts
@@ -14,9 +14,8 @@ type StoragePluginTypes = 'sessionStoragePlugin' | 'localStoragePlugin';
 @Injectable({ providedIn: 'root' })
 export class StoreFactory {
   constructor(private store: Store) {
-
     store.checkForTimeTravel();
-    store.addReducersForImportedState();
+    store.addReducersForImportState();
   }
 
   public createComponentStore<STATE extends object>({

--- a/libs/store/src/services/store.service.spec.ts
+++ b/libs/store/src/services/store.service.spec.ts
@@ -54,14 +54,18 @@ describe('Store', () => {
   );
   const reducerManager = jasmine.createSpyObj<ReducerManager>(
     'ReducerManager',
-    { addReducer: undefined, addReducers: undefined, removeReducer: undefined },
+    {
+      addReducer: undefined,
+      addReducers: undefined,
+      removeReducer: undefined,
+    },
     {
       currentReducers: {
         oldStore: () => undefined,
       },
     }
   );
-  let store: Store;
+  const getStore = (): Store => TestBed.inject(Store);
 
   describe('minimal Dependencies are available', () => {
     beforeEach(() => {
@@ -84,7 +88,6 @@ describe('Store', () => {
         ],
         teardown: { destroyAfterEach: false },
       });
-      store = TestBed.inject(Store);
     });
 
     it('should not show an Error for checkForTimeTravel', () => {
@@ -94,7 +97,7 @@ describe('Store', () => {
 
     it('should not show an Error for addReducersForImportedState', () => {
       const store = TestBed.inject(Store);
-      expect(() => store.addReducersForImportedState()).not.toThrowError();
+      expect(() => store.addReducersForImportState()).not.toThrowError();
     });
 
     it('should create a componentStore without errors', () => {
@@ -144,7 +147,6 @@ describe('Store', () => {
         ],
         teardown: { destroyAfterEach: false },
       });
-      store = TestBed.inject(Store);
     });
 
     describe('checkForTimeTravel', () => {
@@ -162,13 +164,13 @@ describe('Store', () => {
 
         devToolHelper.setCanChangeState.calls.reset();
 
-        store.checkForTimeTravel();
+        getStore().checkForTimeTravel();
 
         expect(devToolHelper.setCanChangeState).toHaveBeenCalledWith(false);
       });
     });
 
-    describe('addReducersForImportedState', () => {
+    describe('addReducersForImportState', () => {
       it('should set setCanChangeState to false', () => {
         liftedState$ = of(
           jasmine.createSpyObj<LiftedState>(
@@ -207,9 +209,12 @@ describe('Store', () => {
 
         reducerManager.addReducer.calls.reset();
 
-        store.addReducersForImportedState();
+        getStore().addReducersForImportState();
 
-        expect(reducerManager.addReducers).toHaveBeenCalled();
+        expect(reducerManager.addReducers).toHaveBeenCalledWith({
+          NEW_STORE: jasmine.any(Function),
+        });
+
         expect(storeDevtools.sweep).toHaveBeenCalled();
       });
     });
@@ -228,7 +233,7 @@ describe('Store', () => {
         });
 
         it('should return default initial state', () => {
-          const { state } = store.createStoreByStoreType({
+          const { state } = getStore().createStoreByStoreType({
             storeName: 'myStore',
             plugins: {},
             defaultState: defaultMyState,
@@ -239,7 +244,7 @@ describe('Store', () => {
         });
 
         it('should return state from sessionStorage plugin', () => {
-          const { state } = store.createStoreByStoreType({
+          const { state } = getStore().createStoreByStoreType({
             storeName: 'myStore',
             defaultState: defaultMyState,
             plugins: {
@@ -255,7 +260,7 @@ describe('Store', () => {
         });
 
         it('should return state from localeStorage plugin', () => {
-          const { state } = store.createStoreByStoreType({
+          const { state } = getStore().createStoreByStoreType({
             storeName: 'myStore',
             defaultState: defaultMyState,
             plugins: {
@@ -274,10 +279,10 @@ describe('Store', () => {
 
     describe('ngrxStore', () => {
       describe('add store to reducerManager', () => {
-        it('should add addReducer for store', () => {
+        it('should add add for store', () => {
           reducerManager.addReducer.calls.reset();
 
-          store.createStoreByStoreType({
+          getStore().createStoreByStoreType({
             storeName: 'testStore',
             defaultState: defaultMyState,
             CreatedStore: ComponentStore,
@@ -287,10 +292,10 @@ describe('Store', () => {
             'testStore'
           );
         });
-        it('should not addReducer an existing reducer to store', () => {
+        it('should not add an existing reducer to store', () => {
           reducerManager.addReducer.calls.reset();
 
-          store.createStoreByStoreType({
+          getStore().createStoreByStoreType({
             storeName: 'oldStore',
             defaultState: defaultMyState,
             CreatedStore: ComponentStore,
@@ -308,7 +313,7 @@ describe('Store', () => {
           });
         });
         it('should ignore action from other store', () => {
-          store.createStoreByStoreType({
+          getStore().createStoreByStoreType({
             storeName: 'testStore',
             defaultState: defaultMyState,
             CreatedStore: ComponentStore,
@@ -331,7 +336,7 @@ describe('Store', () => {
 
         describe('action is current store action', () => {
           it('should merge state with payload', () => {
-            store.createStoreByStoreType({
+            getStore().createStoreByStoreType({
               storeName: 'testStore',
               defaultState: defaultMyState,
               CreatedStore: ComponentStore,
@@ -351,7 +356,7 @@ describe('Store', () => {
           });
 
           it('should return merge default state with payload', () => {
-            store.createStoreByStoreType({
+            getStore().createStoreByStoreType({
               storeName: 'testStore',
               defaultState: defaultMyState,
               CreatedStore: ComponentStore,
@@ -391,7 +396,7 @@ describe('Store', () => {
               stagedActionIds: [0, 1, 2],
             },
           });
-          const { state$ } = store.createStoreByStoreType({
+          const { state$ } = getStore().createStoreByStoreType({
             storeName: 'myStore',
             defaultState: defaultMyState,
             CreatedStore: ComponentStore,
@@ -410,7 +415,7 @@ describe('Store', () => {
 
       describe('store state changes to ClientStoragePlugins', () => {
         it('should store changes to session storage', () => {
-          const myStore = store.createStoreByStoreType({
+          const myStore = getStore().createStoreByStoreType({
             storeName: 'testStore',
             defaultState: defaultMyState,
             plugins: {
@@ -429,7 +434,7 @@ describe('Store', () => {
         });
 
         it('should store changes to localStorage storage', () => {
-          const myStore = store.createStoreByStoreType({
+          const myStore = getStore().createStoreByStoreType({
             storeName: 'testStore',
             defaultState: defaultMyState,
             plugins: {
@@ -448,6 +453,34 @@ describe('Store', () => {
           );
         });
       });
+
+      describe('remove reducer, after destroy', () => {
+        it('should not remove the reducer, when devtools are availible', () => {
+          reducerManager.removeReducer.calls.reset();
+
+          const myStore = getStore().createStoreByStoreType({
+            storeName: 'testStore',
+            defaultState: defaultMyState,
+            CreatedStore: ComponentStore,
+          });
+          myStore.ngOnDestroy();
+
+          expect(reducerManager.removeReducer).not.toHaveBeenCalled();
+        });
+
+        it('should not remove the reducer, when devtools are availible', () => {
+          TestBed.overrideProvider(StoreDevtools, { useValue: null });
+
+          const myStore = getStore().createStoreByStoreType({
+            storeName: 'testStore',
+            defaultState: defaultMyState,
+            CreatedStore: ComponentStore,
+          });
+          myStore.ngOnDestroy();
+
+          expect(reducerManager.removeReducer).toHaveBeenCalled();
+        });
+      });
     });
   });
 
@@ -464,7 +497,7 @@ describe('Store', () => {
       teardown: { destroyAfterEach: false },
     });
 
-    expect(() => TestBed.inject(Store)).toThrow(
+    expect(() => getStore()).toThrow(
       '@ngrx/store is not imported. Please install `@ngrx/store` and import `StoreModule.forRoot({})` in your root module'
     );
   });

--- a/libs/store/src/services/store.service.spec.ts
+++ b/libs/store/src/services/store.service.spec.ts
@@ -10,11 +10,9 @@ import { cold } from 'jasmine-marbles';
 import { StoreDevtools } from '@ngrx/store-devtools';
 import { defer, EMPTY, of } from 'rxjs';
 import { LiftedState } from '@ngrx/store-devtools/src/reducer';
-import {
-  ComponentStore,
-  DevToolHelper,
-} from './stores/component-store.service';
+import { ComponentStore } from './stores/component-store.service';
 import { Store } from './store.service';
+import { DevToolHelper } from './dev-tool-helper.service';
 
 interface MyState {
   myState: string;
@@ -42,8 +40,8 @@ describe('Store', () => {
     }
   );
   const devToolHelper = jasmine.createSpyObj<DevToolHelper>('storeDevtools', {
-    canChangeState: true,
-    setCanChangeState: undefined,
+    isTimeTravelActive: false,
+    setTimeTravelActive: undefined,
   });
   const localStoragePlugin = jasmine.createSpyObj<ClientStoragePlugin>(
     'LocalStoragePlugin',
@@ -69,7 +67,7 @@ describe('Store', () => {
 
   describe('minimal Dependencies are available', () => {
     beforeEach(() => {
-      devToolHelper.canChangeState.and.returnValue(true);
+      devToolHelper.isTimeTravelActive.and.returnValue(false);
       liftedState$ = EMPTY;
       TestBed.configureTestingModule({
         providers: [
@@ -116,7 +114,7 @@ describe('Store', () => {
 
   describe('All Dependencies are available', () => {
     beforeEach(() => {
-      devToolHelper.canChangeState.and.returnValue(true);
+      devToolHelper.isTimeTravelActive.and.returnValue(false);
       liftedState$ = EMPTY;
       TestBed.configureTestingModule({
         providers: [
@@ -150,7 +148,7 @@ describe('Store', () => {
     });
 
     describe('checkForTimeTravel', () => {
-      it('should set setCanChangeState to false', () => {
+      it('should set timeTravelActive to false', () => {
         liftedState$ = of(
           jasmine.createSpyObj<LiftedState>(
             'liftedState',
@@ -162,16 +160,16 @@ describe('Store', () => {
           )
         );
 
-        devToolHelper.setCanChangeState.calls.reset();
+        devToolHelper.setTimeTravelActive.calls.reset();
 
         getStore().checkForTimeTravel();
 
-        expect(devToolHelper.setCanChangeState).toHaveBeenCalledWith(false);
+        expect(devToolHelper.setTimeTravelActive).toHaveBeenCalledWith(true);
       });
     });
 
     describe('addReducersForImportState', () => {
-      it('should set setCanChangeState to false', () => {
+      it('should add new component reducers', () => {
         liftedState$ = of(
           jasmine.createSpyObj<LiftedState>(
             'liftedState',
@@ -379,7 +377,7 @@ describe('Store', () => {
 
       describe('set state from storeDevtools', () => {
         it('should set stateChanges to store', () => {
-          devToolHelper.canChangeState.and.returnValue(false);
+          devToolHelper.isTimeTravelActive.and.returnValue(true);
           liftedState$ = cold('a', {
             a: <Partial<LiftedState>>{
               computedStates: [

--- a/libs/store/src/services/store.service.ts
+++ b/libs/store/src/services/store.service.ts
@@ -44,7 +44,7 @@ export class Store {
     });
   }
 
-  public addReducersForImportedState(): void {
+  public addReducersForImportState(): void {
     this.storeDevtools?.liftedState.subscribe({
       next: ({ monitorState }) => {
         if (monitorState.type === 'IMPORT_STATE') {
@@ -117,6 +117,7 @@ export class Store {
 
     this.syncStoreChangesToClientStorage(storeName, store, storage);
     this.syncNgrxDevtoolStateToStore<STATE>(storeName, store);
+    this.removeReducerAfterDestroy<STATE>(storeName, store);
     return store;
   }
 
@@ -196,6 +197,17 @@ export class Store {
           );
         }
       },
+    });
+  }
+
+  private removeReducerAfterDestroy<STATE extends object>(
+    storeName: string,
+    store: ComponentStore<STATE>
+  ) {
+    store.destroy$.subscribe(() => {
+      if (!this.storeDevtools) {
+        this.reducerManager.removeReducer(storeName);
+      }
     });
   }
 

--- a/libs/store/src/services/store.service.ts
+++ b/libs/store/src/services/store.service.ts
@@ -7,12 +7,10 @@ import { LocalStoragePlugin, SessionStoragePlugin } from '../injection-tokens';
 
 import { ActionReducer, ReducerManager, Store as NgrxStore } from '@ngrx/store';
 import { takeUntil } from 'rxjs';
-import {
-  ComponentStore,
-  DevToolHelper,
-} from './stores/component-store.service';
+import { ComponentStore } from './stores/component-store.service';
 import { StoreDevtools } from '@ngrx/store-devtools';
 import { LiftedState } from '@ngrx/store-devtools/src/reducer';
+import { DevToolHelper } from './dev-tool-helper.service';
 
 type StoragePluginTypes = 'sessionStoragePlugin' | 'localStoragePlugin';
 type Stores = typeof ComponentStore | typeof ComponentLoadingStore;
@@ -37,8 +35,8 @@ export class Store {
   public checkForTimeTravel(): void {
     this.storeDevtools?.liftedState.subscribe({
       next: ({ currentStateIndex, stagedActionIds }) => {
-        this.devToolHelper.setCanChangeState(
-          currentStateIndex === stagedActionIds.length - 1
+        this.devToolHelper.setTimeTravelActive(
+          currentStateIndex !== stagedActionIds.length - 1
         );
       },
     });
@@ -186,7 +184,7 @@ export class Store {
   ) {
     this.storeDevtools?.liftedState.pipe(takeUntil(store.destroy$)).subscribe({
       next: ({ computedStates, currentStateIndex }) => {
-        if (!this.devToolHelper.canChangeState()) {
+        if (this.devToolHelper.isTimeTravelActive()) {
           store.setState(
             computedStates[currentStateIndex].state[storeName],
             '',

--- a/libs/store/src/services/stores/component-loading-store.service.spec.ts
+++ b/libs/store/src/services/stores/component-loading-store.service.spec.ts
@@ -12,7 +12,7 @@ import {
   StateToken,
   StoreNameToken,
 } from '../../injection-tokens/state.token';
-import {DevToolHelper} from "./component-store.service";
+import {DevToolHelper} from "../dev-tool-helper.service";
 
 describe('LoadingStore', () => {
   let store: ComponentLoadingStore<string, number>;

--- a/libs/store/src/services/stores/component-loading-store.service.ts
+++ b/libs/store/src/services/stores/component-loading-store.service.ts
@@ -6,7 +6,8 @@ import { StateToken, StoreNameToken } from '../../injection-tokens/state.token';
 import { Store as NgrxStore } from '@ngrx/store';
 import { getEffectActionName } from '../action-creator';
 import { EffectStates } from '../../enums/effect-states.enum';
-import { ComponentStore, DevToolHelper } from './component-store.service';
+import { ComponentStore } from './component-store.service';
+import {DevToolHelper} from "../dev-tool-helper.service";
 
 export const getDefaultComponentLoadingState = <ITEM, ERROR>(
   state: Partial<LoadingStoreState<ITEM, ERROR>> = {}

--- a/libs/store/src/services/stores/component-store.service.spec.ts
+++ b/libs/store/src/services/stores/component-store.service.spec.ts
@@ -1,8 +1,9 @@
 import { TestBed } from '@angular/core/testing';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { getCustomAction } from '../action-creator';
-import { ComponentStore, DevToolHelper } from './component-store.service';
+import { ComponentStore } from './component-store.service';
 import { StateToken, StoreNameToken } from '../../injection-tokens/state.token';
+import {DevToolHelper} from "../dev-tool-helper.service";
 
 interface MyState {
   myState: string;
@@ -19,7 +20,7 @@ describe('ComponentStore', () => {
   const storeName = 'myStore';
 
   beforeEach(() => {
-    devToolHelper.setCanChangeState(true);
+    devToolHelper.setTimeTravelActive(false);
     TestBed.configureTestingModule({
       providers: [
         {
@@ -92,7 +93,7 @@ describe('ComponentStore', () => {
 
     describe('can not change state', () => {
       beforeEach(() => {
-        devToolHelper.setCanChangeState(false)
+        devToolHelper.setTimeTravelActive(true)
       });
       it('should not set state if can not changed', () => {
         store.setState((state) => ({ ...state, optionalValue: 'test' }));
@@ -171,7 +172,7 @@ describe('ComponentStore', () => {
 
     describe('can not change state', () => {
       beforeEach(() => {
-        devToolHelper.setCanChangeState(false);
+        devToolHelper.setTimeTravelActive(true);
       });
       it('should not set state if can not changed', () => {
         store.patchState((state) => ({ ...state, optionalValue: 'test' }));

--- a/libs/store/src/services/stores/component-store.service.ts
+++ b/libs/store/src/services/stores/component-store.service.ts
@@ -3,19 +3,8 @@ import { Inject, Injectable } from '@angular/core';
 import { StateToken, StoreNameToken } from '../../injection-tokens/state.token';
 import { Store as NgrxStore } from '@ngrx/store';
 import { getCustomAction } from '../action-creator';
+import {DevToolHelper} from "../dev-tool-helper.service";
 
-@Injectable({providedIn: 'root'})
-export class DevToolHelper {
-  private _canChangeState = true;
-
-  setCanChangeState(isLastIndex: boolean) {
-    this._canChangeState = isLastIndex;
-  }
-
-   canChangeState(): boolean {
-    return this._canChangeState;
-  }
-}
 
 @Injectable({ providedIn: 'root' })
 export class ComponentStore<
@@ -28,7 +17,7 @@ export class ComponentStore<
     @Inject(StateToken) state: STATE
   ) {
     super(state);
-    if (this.devToolHelper.canChangeState()) {
+    if (!this.devToolHelper.isTimeTravelActive()) {
       this.dispatchCustomAction('init', state);
     }
   }
@@ -48,7 +37,7 @@ export class ComponentStore<
       forced?: boolean;
     } = {}
   ) {
-    if (!this.devToolHelper.canChangeState() && !forced) {
+    if (this.devToolHelper.isTimeTravelActive() && !forced) {
       return;
     }
     const newState =
@@ -65,7 +54,7 @@ export class ComponentStore<
       | ((state: STATE) => Partial<STATE>),
     action: string = 'PATCH_STATE'
   ) {
-    if (!this.devToolHelper.canChangeState()) {
+    if (this.devToolHelper.isTimeTravelActive()) {
       return;
     }
 


### PR DESCRIPTION
Only Remove the Store from the reducer, if the Store destroyed and no Devtools configured

close #33